### PR TITLE
Initialize display of timeEdit from none to flex when time is clicked.

### DIFF
--- a/app.js
+++ b/app.js
@@ -99,7 +99,7 @@ function initializeSec(){
 }
 
 time.addEventListener("click", ()=>{
-    timeEdit.style.display = "block";
+    timeEdit.style.display = "flex";
 })
 
 
@@ -203,8 +203,8 @@ function backgroundChange(){
 
 function light(){
     toggleBtnFuncRight(circle, lightSun, darkMoon);
-    lightSun.style.color = "white";
-    circle.style.backgroundColor = "white";
+    lightSun.style.color = "#f5cbbb";
+    circle.style.backgroundColor = "#f5cbbb";
     toggleBtn.style.backgroundColor = "black";
     backgroundChange();
     modeText.innerText = "Light Mode";


### PR DESCRIPTION
The display set initially was block when time was clicked which created styling inappropriate and elements disorganized.
Now, the display is set to flex when time is clicked.